### PR TITLE
Use The Most Recent Debate Index From Mongo To Stop The Debate Gatherer

### DIFF
--- a/src/Provinces/BC/MainRequest.py
+++ b/src/Provinces/BC/MainRequest.py
@@ -54,7 +54,6 @@ class BC():
 
     def get_daily_data(self):
         latest_date = self.cluster['BC_Legislative_Archive']['Debates'].find().limit(1).sort('_id', direction=pymongo.DESCENDING)[0]['date']
-        print(latest_date)
 
         self.drive.get('https://www.leg.bc.ca/')
 
@@ -68,28 +67,22 @@ class BC():
         day = ''
         links_to_check = []
         temp_links_to_check = []
-        offset = 0
 
         # EROXL:TODO: Switch this to just checking if we don't have that debate and exiting if we have it
         for i in range(len(outer_path_for_debates.find_elements(By.XPATH, './*'))):
-            i = i-offset
-            
             # ~ Get the title of the debate (ex. Tuesday, June 8, 2021, Morning — Committee C	Blues)
             current_debate_text = outer_path_for_debates.find_elements(By.XPATH, './*')[i].text.lower()
             if current_debate_text != '' and 'blues' not in current_debate_text and 'live' not in current_debate_text and 'page' not in current_debate_text:
-
                 if current_debate_text.split(',')[0] == day or day == '':
                     day = current_debate_text.split(',')[0]
                     temp_links_to_check.append(outer_path_for_debates.find_elements(By.XPATH,'./*')[i].find_element(By.CLASS_NAME, 'BCLASS-Hansard-HTMLLink').find_element(By.XPATH, './*').get_attribute('href'))
-
-                elif len(links_to_check) >= 3:
-                    break
+                    if temp_links_to_check[0].split('/')[-1].split('am')[0].split('pm')[0] == latest_date:
+                        break
                 else:
                     day = ''
                     temp_links_to_check.reverse()
                     links_to_check.append(temp_links_to_check)
                     temp_links_to_check = []
-                    offset += 1
 
         links_to_check.reverse()
 

--- a/src/Provinces/BC/MainRequest.py
+++ b/src/Provinces/BC/MainRequest.py
@@ -1,5 +1,6 @@
 import time
 from pymongo import MongoClient
+import pymongo
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 
@@ -52,6 +53,9 @@ class BC():
 
 
     def get_daily_data(self):
+        latest_date = self.cluster['BC_Legislative_Archive']['Debates'].find().limit(1).sort('_id', direction=pymongo.DESCENDING)[0]['date']
+        print(latest_date)
+
         self.drive.get('https://www.leg.bc.ca/')
 
         # ~ Click on the debates portion of the page


### PR DESCRIPTION
# About
Using the most recent debate index from the mongo server we can stop the debate gatherer once it reaches the most recently indexed value instead of just indexing the most recent 3 debates.

# Reasoning
It cleans up the script a ton  not to gather a static amount of debates per day and instead adapt to how many we're formatted that day so we never miss out on any.

# Checklist
- [x] Gather the most recent date from the mongo server
- [x] Check the links dates until we find the most recent dates